### PR TITLE
feat: auto-download hsml binary from GitHub releases

### DIFF
--- a/client/src/binary.ts
+++ b/client/src/binary.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import type { IncomingMessage } from 'node:http';
 import { get as httpsGet } from 'node:https';
 import { join } from 'node:path';
@@ -45,12 +45,14 @@ export async function resolveServerPath(context: ExtensionContext): Promise<stri
   try {
     const metadata = JSON.parse(await readFile(metadataPath, 'utf-8')) as BinaryMetadata;
     if (metadata.version) {
+      // Verify the binary file actually exists
+      await access(binaryPath);
       // Binary exists, check for updates in the background
       checkForUpdate(context).catch(() => {});
       return binaryPath;
     }
   } catch {
-    // No metadata or invalid — continue to download prompt
+    // No metadata, invalid, or binary missing — continue to download prompt
   }
 
   // Prompt user to download
@@ -173,12 +175,36 @@ async function checkForUpdate(context: ExtensionContext): Promise<void> {
   }
 
   try {
-    await downloadBinary(context, latestVersion);
+    // Download to a staging directory to avoid overwriting the running binary
+    const stagingDir = join(context.globalStorageUri.fsPath, '_staging');
+    await mkdir(stagingDir, { recursive: true });
+
+    const stagingContext = {
+      ...context,
+      globalStorageUri: { fsPath: stagingDir } as typeof context.globalStorageUri,
+    } as ExtensionContext;
+
+    await downloadBinary(stagingContext, latestVersion);
+
+    // Move staged binary to the main location on reload
+    const binaryName = getBinaryName();
+    const stagedBinary = join(stagingDir, binaryName);
+    const targetBinary = join(context.globalStorageUri.fsPath, binaryName);
+
     const reload = await window.showInformationMessage(
       'hsml has been updated. Reload window to apply?',
       'Reload',
     );
     if (reload === 'Reload') {
+      // Replace the binary and metadata before reloading
+      await rm(targetBinary, { force: true });
+      const { rename } = await import('node:fs/promises');
+      await rename(stagedBinary, targetBinary);
+      await rename(
+        join(stagingDir, 'metadata.json'),
+        join(context.globalStorageUri.fsPath, 'metadata.json'),
+      );
+      await rm(stagingDir, { recursive: true, force: true });
       await commands.executeCommand('workbench.action.reloadWindow');
     }
   } catch (error) {
@@ -271,21 +297,26 @@ function followRedirects(url: string, options?: { timeout?: number }): Promise<I
 }
 
 async function downloadFile(url: string, destPath: string): Promise<void> {
-  const res = await followRedirects(url);
+  const res = await followRedirects(url, { timeout: 60_000 });
   const file = createWriteStream(destPath);
 
-  return new Promise((resolve, reject) => {
-    res.pipe(file);
-    file.on('finish', () => {
-      file.close();
-      resolve();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      res.pipe(file);
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+      file.on('error', (err: Error) => {
+        file.close();
+        reject(err);
+      });
+      res.on('error', reject);
     });
-    file.on('error', (err: Error) => {
-      file.close();
-      reject(err);
-    });
-    res.on('error', reject);
-  });
+  } catch (error) {
+    await rm(destPath, { force: true });
+    throw error;
+  }
 }
 
 async function fetchJson(url: string): Promise<unknown> {

--- a/client/src/binary.ts
+++ b/client/src/binary.ts
@@ -1,0 +1,306 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import type { IncomingMessage } from 'node:http';
+import { get as httpsGet } from 'node:https';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type { ExtensionContext } from 'vscode';
+import { ProgressLocation, commands, window, workspace } from 'vscode';
+import {
+  getAssetName,
+  getBinaryName,
+  getChecksumUrl,
+  getDownloadUrl,
+  getLatestReleaseApiUrl,
+} from './platform.js';
+
+const execFileAsync = promisify(execFile);
+
+interface BinaryMetadata {
+  version: string;
+  downloadedAt: string;
+}
+
+export async function resolveServerPath(context: ExtensionContext): Promise<string | undefined> {
+  const config = workspace.getConfiguration('hsml');
+  const serverPath = config.get<string>('server.path', 'hsml');
+
+  // User override — use as-is
+  if (serverPath !== 'hsml') {
+    return serverPath;
+  }
+
+  // Check if hsml is in PATH
+  if (await isInPath()) {
+    return 'hsml';
+  }
+
+  // Check for previously downloaded binary
+  const storagePath = context.globalStorageUri.fsPath;
+  const binaryPath = join(storagePath, getBinaryName());
+  const metadataPath = join(storagePath, 'metadata.json');
+
+  try {
+    const metadata = JSON.parse(await readFile(metadataPath, 'utf-8')) as BinaryMetadata;
+    if (metadata.version) {
+      // Binary exists, check for updates in the background
+      checkForUpdate(context).catch(() => {});
+      return binaryPath;
+    }
+  } catch {
+    // No metadata or invalid — continue to download prompt
+  }
+
+  // Prompt user to download
+  return promptDownload(context);
+}
+
+async function isInPath(): Promise<boolean> {
+  const command = process.platform === 'win32' ? 'where' : 'which';
+  try {
+    await execFileAsync(command, ['hsml']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function promptDownload(context: ExtensionContext): Promise<string | undefined> {
+  const answer = await window.showInformationMessage(
+    'The hsml binary was not found. Download it from GitHub?',
+    'Download',
+    'Cancel',
+  );
+
+  if (answer !== 'Download') {
+    return undefined;
+  }
+
+  try {
+    return await downloadBinary(context);
+  } catch (error) {
+    window.showErrorMessage(
+      `Failed to download hsml: ${error instanceof Error ? error.message : error}`,
+    );
+    return undefined;
+  }
+}
+
+export async function downloadBinary(context: ExtensionContext, version?: string): Promise<string> {
+  const resolvedVersion = version ?? (await fetchLatestVersion());
+  const storagePath = context.globalStorageUri.fsPath;
+
+  await mkdir(storagePath, { recursive: true });
+
+  const binaryPath = await window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: `Downloading hsml v${resolvedVersion}...`,
+      cancellable: false,
+    },
+    async (progress) => {
+      const assetName = getAssetName(resolvedVersion);
+      const archivePath = join(storagePath, assetName);
+
+      // Download archive
+      progress.report({ message: 'Downloading binary...' });
+      await downloadFile(getDownloadUrl(resolvedVersion), archivePath);
+
+      // Verify checksum
+      progress.report({ message: 'Verifying checksum...' });
+      await verifyChecksum(archivePath, assetName, resolvedVersion);
+
+      // Extract
+      progress.report({ message: 'Extracting...' });
+      await extractArchive(archivePath, storagePath);
+
+      // Cleanup archive
+      await rm(archivePath, { force: true });
+
+      // Set executable permission on non-Windows
+      const binPath = join(storagePath, getBinaryName());
+      if (process.platform !== 'win32') {
+        await chmod(binPath, 0o755);
+      }
+
+      // Write metadata
+      const metadata: BinaryMetadata = {
+        version: resolvedVersion,
+        downloadedAt: new Date().toISOString(),
+      };
+      await writeFile(join(storagePath, 'metadata.json'), JSON.stringify(metadata, null, 2));
+
+      return binPath;
+    },
+  );
+
+  return binaryPath;
+}
+
+async function checkForUpdate(context: ExtensionContext): Promise<void> {
+  const storagePath = context.globalStorageUri.fsPath;
+  const metadataPath = join(storagePath, 'metadata.json');
+
+  let currentVersion: string;
+  try {
+    const metadata = JSON.parse(await readFile(metadataPath, 'utf-8')) as BinaryMetadata;
+    currentVersion = metadata.version;
+  } catch {
+    return;
+  }
+
+  let latestVersion: string;
+  try {
+    latestVersion = await fetchLatestVersion();
+  } catch {
+    return; // Silent failure — no internet or rate limited
+  }
+
+  if (latestVersion.localeCompare(currentVersion, undefined, { numeric: true }) <= 0) {
+    return; // Already up to date
+  }
+
+  const answer = await window.showInformationMessage(
+    `A new version of hsml (v${latestVersion}) is available. Update?`,
+    'Update',
+    'Dismiss',
+  );
+
+  if (answer !== 'Update') {
+    return;
+  }
+
+  try {
+    await downloadBinary(context, latestVersion);
+    const reload = await window.showInformationMessage(
+      'hsml has been updated. Reload window to apply?',
+      'Reload',
+    );
+    if (reload === 'Reload') {
+      await commands.executeCommand('workbench.action.reloadWindow');
+    }
+  } catch (error) {
+    window.showErrorMessage(
+      `Failed to update hsml: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+}
+
+async function fetchLatestVersion(): Promise<string> {
+  const data = (await fetchJson(getLatestReleaseApiUrl())) as { tag_name: string };
+  return data.tag_name.replace(/^v/, '');
+}
+
+async function verifyChecksum(
+  archivePath: string,
+  assetName: string,
+  version: string,
+): Promise<void> {
+  const checksumText = await fetchText(getChecksumUrl(version));
+  const lines = checksumText.trim().split('\n');
+
+  let expectedHash: string | undefined;
+  for (const line of lines) {
+    const [hash, name] = line.trim().split(/\s+/);
+    if (name === assetName && hash) {
+      expectedHash = hash;
+      break;
+    }
+  }
+
+  if (!expectedHash) {
+    throw new Error(`Checksum not found for ${assetName}`);
+  }
+
+  const actualHash = await computeSha256(archivePath);
+  if (actualHash !== expectedHash) {
+    await rm(archivePath, { force: true });
+    throw new Error(
+      `Checksum mismatch for ${assetName}: expected ${expectedHash}, got ${actualHash}`,
+    );
+  }
+}
+
+async function computeSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+    stream.on('data', (data: string | Buffer) => hash.update(data));
+    stream.on('end', () => resolve(hash.digest('hex')));
+    stream.on('error', reject);
+  });
+}
+
+async function extractArchive(archivePath: string, destDir: string): Promise<void> {
+  await execFileAsync('tar', ['-xf', archivePath, '-C', destDir]);
+}
+
+function followRedirects(url: string, options?: { timeout?: number }): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    const req = httpsGet(
+      url,
+      { headers: { 'User-Agent': 'vscode-hsml' }, timeout: options?.timeout },
+      (res) => {
+        if (res.statusCode === 302 || res.statusCode === 301) {
+          const location = res.headers.location;
+          if (!location) {
+            reject(new Error('Redirect without location header'));
+            return;
+          }
+          followRedirects(location, options).then(resolve, reject);
+          return;
+        }
+
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+          return;
+        }
+
+        resolve(res);
+      },
+    );
+
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error(`Request timed out: ${url}`));
+    });
+  });
+}
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  const res = await followRedirects(url);
+  const file = createWriteStream(destPath);
+
+  return new Promise((resolve, reject) => {
+    res.pipe(file);
+    file.on('finish', () => {
+      file.close();
+      resolve();
+    });
+    file.on('error', (err: Error) => {
+      file.close();
+      reject(err);
+    });
+    res.on('error', reject);
+  });
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const text = await fetchText(url);
+  return JSON.parse(text);
+}
+
+async function fetchText(url: string): Promise<string> {
+  const res = await followRedirects(url, { timeout: 10_000 });
+  return new Promise((resolve, reject) => {
+    let data = '';
+    res.on('data', (chunk: Buffer) => {
+      data += chunk.toString();
+    });
+    res.on('end', () => resolve(data));
+    res.on('error', reject);
+  });
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,12 +2,15 @@ import type { ExtensionContext } from 'vscode';
 import { workspace } from 'vscode';
 import type { Executable, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import { LanguageClient } from 'vscode-languageclient/node';
+import { resolveServerPath } from './binary.js';
 
 let client: LanguageClient | undefined;
 
-export function activate(_context: ExtensionContext) {
-  const config = workspace.getConfiguration('hsml');
-  const serverPath = config.get<string>('server.path', 'hsml');
+export async function activate(context: ExtensionContext) {
+  const serverPath = await resolveServerPath(context);
+  if (!serverPath) {
+    return;
+  }
 
   const run: Executable = {
     command: serverPath,

--- a/client/src/platform.ts
+++ b/client/src/platform.ts
@@ -1,0 +1,52 @@
+const ARCH_MAP: Record<string, string> = {
+  x64: 'x86_64',
+  arm64: 'aarch64',
+};
+
+const PLATFORM_MAP: Record<string, string> = {
+  darwin: 'apple-darwin',
+  linux: 'unknown-linux-gnu',
+  win32: 'pc-windows-msvc',
+};
+
+const REPO = 'hsml-lab/hsml';
+
+export function getReleaseArch(): string {
+  const arch = ARCH_MAP[process.arch];
+  if (!arch) {
+    throw new Error(`Unsupported architecture: ${process.arch}`);
+  }
+  return arch;
+}
+
+export function getReleasePlatform(): string {
+  const platform = PLATFORM_MAP[process.platform];
+  if (!platform) {
+    throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+  return platform;
+}
+
+export function getArchiveExtension(): string {
+  return process.platform === 'win32' ? '.zip' : '.tar.gz';
+}
+
+export function getBinaryName(): string {
+  return process.platform === 'win32' ? 'hsml.exe' : 'hsml';
+}
+
+export function getAssetName(_version: string): string {
+  return `hsml-${getReleaseArch()}-${getReleasePlatform()}${getArchiveExtension()}`;
+}
+
+export function getDownloadUrl(version: string): string {
+  return `https://github.com/${REPO}/releases/download/v${version}/${getAssetName(version)}`;
+}
+
+export function getChecksumUrl(version: string): string {
+  return `https://github.com/${REPO}/releases/download/v${version}/SHA256SUMS.txt`;
+}
+
+export function getLatestReleaseApiUrl(): string {
+  return `https://api.github.com/repos/${REPO}/releases/latest`;
+}

--- a/tests/__mocks__/binary.ts
+++ b/tests/__mocks__/binary.ts
@@ -1,3 +1,3 @@
 import { vi } from 'vitest';
 
-export const resolveServerPath = vi.fn(() => Promise.resolve('hsml'));
+export const resolveServerPath = vi.fn(() => Promise.resolve('hsml' as string | undefined));

--- a/tests/__mocks__/binary.ts
+++ b/tests/__mocks__/binary.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+export const resolveServerPath = vi.fn(() => Promise.resolve('hsml'));

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -6,3 +6,26 @@ export const workspace = {
   })),
   createFileSystemWatcher: vi.fn(),
 };
+
+export const window = {
+  showInformationMessage: vi.fn(),
+  showErrorMessage: vi.fn(),
+  withProgress: vi.fn((_options: unknown, task: (progress: unknown) => Promise<unknown>) =>
+    task({ report: vi.fn() }),
+  ),
+};
+
+export const ProgressLocation = {
+  Notification: 15,
+};
+
+export const Uri = {
+  file: vi.fn((path: string) => ({ fsPath: path, scheme: 'file' })),
+  joinPath: vi.fn((base: { fsPath: string }, ...segments: string[]) => ({
+    fsPath: [base.fsPath, ...segments].join('/'),
+  })),
+};
+
+export const commands = {
+  executeCommand: vi.fn(),
+};

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -45,7 +45,7 @@ describe('deactivate', () => {
     const { mockStop } = await import('./__mocks__/vscode-languageclient-node.js');
     const { activate, deactivate } = await import('../client/src/extension.js');
     await activate(mockContext);
-    deactivate();
+    await deactivate();
     expect(mockStop).toHaveBeenCalled();
   });
 });

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExtensionContext } from 'vscode';
-
-vi.mock('../client/src/binary.js', () => ({
-  resolveServerPath: vi.fn(() => Promise.resolve('hsml')),
-}));
+import { resolveServerPath } from './__mocks__/binary.js';
 
 const mockContext = {
   globalStorageUri: { fsPath: '/tmp/test-storage' },
@@ -11,10 +8,21 @@ const mockContext = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.resetModules();
+  resolveServerPath.mockResolvedValue('hsml');
 });
 
 describe('activate', () => {
+  it('should not start client when no binary available', async () => {
+    resolveServerPath.mockResolvedValue(undefined);
+    const { workspace } = await import('vscode');
+    const { mockStart } = await import('./__mocks__/vscode-languageclient-node.js');
+    const { activate } = await import('../client/src/extension.js');
+    await activate(mockContext);
+
+    expect(workspace.createFileSystemWatcher).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
   it('should watch hsml files', async () => {
     const { workspace } = await import('vscode');
     const { activate } = await import('../client/src/extension.js');
@@ -33,17 +41,10 @@ describe('activate', () => {
 });
 
 describe('deactivate', () => {
-  it('should return undefined when no client', async () => {
-    const { deactivate } = await import('../client/src/extension.js');
-    const result = deactivate();
-    expect(result).toBeUndefined();
-  });
-
   it('should stop the client when active', async () => {
     const { mockStop } = await import('./__mocks__/vscode-languageclient-node.js');
     const { activate, deactivate } = await import('../client/src/extension.js');
     await activate(mockContext);
-
     deactivate();
     expect(mockStop).toHaveBeenCalled();
   });

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,34 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ExtensionContext } from 'vscode';
 
+vi.mock('../client/src/binary.js', () => ({
+  resolveServerPath: vi.fn(() => Promise.resolve('hsml')),
+}));
+
+const mockContext = {
+  globalStorageUri: { fsPath: '/tmp/test-storage' },
+} as unknown as ExtensionContext;
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.resetModules();
 });
 
 describe('activate', () => {
-  it('should read hsml configuration', async () => {
-    const { workspace } = await import('vscode');
-    const { activate } = await import('../client/src/extension.js');
-    activate({} as unknown as ExtensionContext);
-
-    expect(workspace.getConfiguration).toHaveBeenCalledWith('hsml');
-  });
-
-  it('should use default server path "hsml"', async () => {
-    const { workspace } = await import('vscode');
-    const { activate } = await import('../client/src/extension.js');
-    activate({} as unknown as ExtensionContext);
-
-    const getConfig = workspace.getConfiguration as ReturnType<typeof vi.fn>;
-    const mockConfig = getConfig.mock.results[0]?.value;
-    expect(mockConfig.get).toHaveBeenCalledWith('server.path', 'hsml');
-  });
-
   it('should watch hsml files', async () => {
     const { workspace } = await import('vscode');
     const { activate } = await import('../client/src/extension.js');
-    activate({} as unknown as ExtensionContext);
+    await activate(mockContext);
 
     expect(workspace.createFileSystemWatcher).toHaveBeenCalledWith('**/*.hsml');
   });
@@ -36,7 +26,7 @@ describe('activate', () => {
   it('should start the language client', async () => {
     const { mockStart } = await import('./__mocks__/vscode-languageclient-node.js');
     const { activate } = await import('../client/src/extension.js');
-    activate({} as unknown as ExtensionContext);
+    await activate(mockContext);
 
     expect(mockStart).toHaveBeenCalled();
   });
@@ -52,7 +42,7 @@ describe('deactivate', () => {
   it('should stop the client when active', async () => {
     const { mockStop } = await import('./__mocks__/vscode-languageclient-node.js');
     const { activate, deactivate } = await import('../client/src/extension.js');
-    activate({} as unknown as ExtensionContext);
+    await activate(mockContext);
 
     deactivate();
     expect(mockStop).toHaveBeenCalled();

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getArchiveExtension,
+  getAssetName,
+  getBinaryName,
+  getChecksumUrl,
+  getDownloadUrl,
+  getLatestReleaseApiUrl,
+} from '../client/src/platform.js';
+
+describe('platform', () => {
+  it('should return correct archive extension for current platform', () => {
+    const ext = getArchiveExtension();
+    if (process.platform === 'win32') {
+      expect(ext).toBe('.zip');
+    } else {
+      expect(ext).toBe('.tar.gz');
+    }
+  });
+
+  it('should return correct binary name for current platform', () => {
+    const name = getBinaryName();
+    if (process.platform === 'win32') {
+      expect(name).toBe('hsml.exe');
+    } else {
+      expect(name).toBe('hsml');
+    }
+  });
+
+  it('should construct asset name with version', () => {
+    const name = getAssetName('0.4.1');
+    expect(name).toMatch(
+      /^hsml-(x86_64|aarch64)-(apple-darwin|unknown-linux-gnu|pc-windows-msvc)\.(tar\.gz|zip)$/,
+    );
+  });
+
+  it('should construct download URL', () => {
+    const url = getDownloadUrl('0.4.1');
+    expect(url).toMatch(
+      /^https:\/\/github\.com\/hsml-lab\/hsml\/releases\/download\/v0\.4\.1\/hsml-/,
+    );
+  });
+
+  it('should construct checksum URL', () => {
+    const url = getChecksumUrl('0.4.1');
+    expect(url).toBe('https://github.com/hsml-lab/hsml/releases/download/v0.4.1/SHA256SUMS.txt');
+  });
+
+  it('should return the latest release API URL', () => {
+    const url = getLatestReleaseApiUrl();
+    expect(url).toBe('https://api.github.com/repos/hsml-lab/hsml/releases/latest');
+  });
+});

--- a/tests/platform.test.ts
+++ b/tests/platform.test.ts
@@ -6,48 +6,62 @@ import {
   getChecksumUrl,
   getDownloadUrl,
   getLatestReleaseApiUrl,
+  getReleaseArch,
+  getReleasePlatform,
 } from '../client/src/platform.js';
 
+const ARCH_MAP: Record<string, string> = {
+  x64: 'x86_64',
+  arm64: 'aarch64',
+};
+
+const PLATFORM_MAP: Record<string, string> = {
+  darwin: 'apple-darwin',
+  linux: 'unknown-linux-gnu',
+  win32: 'pc-windows-msvc',
+};
+
 describe('platform', () => {
+  const expectedArch = ARCH_MAP[process.arch]!;
+  const expectedPlatform = PLATFORM_MAP[process.platform]!;
+  const expectedExt = process.platform === 'win32' ? '.zip' : '.tar.gz';
+  const expectedAsset = `hsml-${expectedArch}-${expectedPlatform}${expectedExt}`;
+
+  it('should map process.arch to release arch', () => {
+    expect(getReleaseArch()).toBe(expectedArch);
+  });
+
+  it('should map process.platform to release platform', () => {
+    expect(getReleasePlatform()).toBe(expectedPlatform);
+  });
+
   it('should return correct archive extension for current platform', () => {
-    const ext = getArchiveExtension();
-    if (process.platform === 'win32') {
-      expect(ext).toBe('.zip');
-    } else {
-      expect(ext).toBe('.tar.gz');
-    }
+    expect(getArchiveExtension()).toBe(expectedExt);
   });
 
   it('should return correct binary name for current platform', () => {
-    const name = getBinaryName();
-    if (process.platform === 'win32') {
-      expect(name).toBe('hsml.exe');
-    } else {
-      expect(name).toBe('hsml');
-    }
+    expect(getBinaryName()).toBe(process.platform === 'win32' ? 'hsml.exe' : 'hsml');
   });
 
-  it('should construct asset name with version', () => {
-    const name = getAssetName('0.4.1');
-    expect(name).toMatch(
-      /^hsml-(x86_64|aarch64)-(apple-darwin|unknown-linux-gnu|pc-windows-msvc)\.(tar\.gz|zip)$/,
-    );
+  it('should construct exact asset name for current platform', () => {
+    expect(getAssetName('0.4.1')).toBe(expectedAsset);
   });
 
-  it('should construct download URL', () => {
-    const url = getDownloadUrl('0.4.1');
-    expect(url).toMatch(
-      /^https:\/\/github\.com\/hsml-lab\/hsml\/releases\/download\/v0\.4\.1\/hsml-/,
+  it('should construct exact download URL for current platform', () => {
+    expect(getDownloadUrl('0.4.1')).toBe(
+      `https://github.com/hsml-lab/hsml/releases/download/v0.4.1/${expectedAsset}`,
     );
   });
 
   it('should construct checksum URL', () => {
-    const url = getChecksumUrl('0.4.1');
-    expect(url).toBe('https://github.com/hsml-lab/hsml/releases/download/v0.4.1/SHA256SUMS.txt');
+    expect(getChecksumUrl('0.4.1')).toBe(
+      'https://github.com/hsml-lab/hsml/releases/download/v0.4.1/SHA256SUMS.txt',
+    );
   });
 
   it('should return the latest release API URL', () => {
-    const url = getLatestReleaseApiUrl();
-    expect(url).toBe('https://api.github.com/repos/hsml-lab/hsml/releases/latest');
+    expect(getLatestReleaseApiUrl()).toBe(
+      'https://api.github.com/repos/hsml-lab/hsml/releases/latest',
+    );
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ import { join } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  test: {
+    coverage: {
+      exclude: ['tests/__mocks__/**'],
+    },
+  },
   resolve: {
     alias: {
       vscode: join(import.meta.dirname, 'tests/__mocks__/vscode.ts'),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         import.meta.dirname,
         'tests/__mocks__/vscode-languageclient-node.ts',
       ),
+      './binary.js': join(import.meta.dirname, 'tests/__mocks__/binary.ts'),
     },
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic discovery, user-prompted download/verification, and staged updates for the bundled server binary, with background update checks.
  * Extension activation can now exit early when no runnable server binary is available (no language client started).

* **Tests**
  * Added platform-specific unit tests and mocks for binary resolution and VS Code APIs.
  * Test coverage config updated to exclude test mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->