### PR TITLE
fix: use workflow_run ref for tag checkout and verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -35,8 +37,10 @@ jobs:
         run: pnpm run build
 
       - name: Verify tag matches package version
+        env:
+          TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
+          TAG="${TAG#v}"
           PKG_VERSION="$(node -e "import('./package.json',{with:{type:'json'}}).then(m=>process.stdout.write(m.default.version))")"
           [ "$TAG" = "$PKG_VERSION" ] || {
             echo "Tag version ($TAG) does not match package.json version ($PKG_VERSION)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the publish workflow to pin the checkout to the exact commit for more reliable branch tracking.
  * Adjusted how the workflow derives and normalizes the release tag (now strips a leading "v") before comparing it to the package version, improving version verification during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->