### PR TITLE
feat: add HSML syntax highlighting in Vue SFCs

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,16 @@
           "source.ts": "typescript",
           "source.ts.embedded.html.vue": "typescript"
         }
+      },
+      {
+        "scopeName": "vue.hsml.codeblock",
+        "path": "./syntaxes/vue-hsml.tmLanguage.json",
+        "injectTo": [
+          "text.html.vue"
+        ],
+        "embeddedLanguages": {
+          "text.hsml": "hsml"
+        }
       }
     ],
     "languages": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "client/out",
     "client/package.json",
     "language-configuration.json",
-    "syntaxes/hsml.tmLanguage.json"
+    "syntaxes/hsml.tmLanguage.json",
+    "syntaxes/vue-hsml.tmLanguage.json"
   ],
   "type": "module",
   "main": "./client/out/extension.js",

--- a/syntaxes/vue-hsml.tmLanguage.json
+++ b/syntaxes/vue-hsml.tmLanguage.json
@@ -1,0 +1,35 @@
+{
+  "scopeName": "vue.hsml.codeblock",
+  "injectionSelector": "L:text.html.vue",
+  "patterns": [
+    {
+      "begin": "([a-zA-Z0-9:-]+)\\b(?=[^>]*\\blang\\s*=\\s*(['\"]?)hsml\\b\\2)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.tag.$1.html.vue"
+        }
+      },
+      "end": "(</)(\\1)\\s*(?=>)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.tag.begin.html.vue"
+        },
+        "2": {
+          "name": "entity.name.tag.$2.html.vue"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(?<=>)",
+          "end": "(?=<\\/)",
+          "name": "text.hsml",
+          "patterns": [
+            {
+              "include": "text.hsml"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/syntaxes/vue-hsml.tmLanguage.json
+++ b/syntaxes/vue-hsml.tmLanguage.json
@@ -20,6 +20,32 @@
       },
       "patterns": [
         {
+          "comment": "tag attributes before the closing >",
+          "begin": "\\G",
+          "end": ">",
+          "endCaptures": {
+            "0": { "name": "punctuation.definition.tag.end.html.vue" }
+          },
+          "patterns": [
+            {
+              "match": "\\b(lang)\\s*=\\s*(['\"])(hsml)\\2",
+              "captures": {
+                "1": { "name": "entity.other.attribute-name.html.vue" },
+                "2": { "name": "punctuation.definition.string.begin.html.vue" },
+                "3": { "name": "string.quoted.html.vue" }
+              }
+            },
+            {
+              "match": "\\b([a-zA-Z-]+)\\s*=\\s*(['\"])([^'\"]*?)\\2",
+              "captures": {
+                "1": { "name": "entity.other.attribute-name.html.vue" },
+                "2": { "name": "punctuation.definition.string.begin.html.vue" },
+                "3": { "name": "string.quoted.html.vue" }
+              }
+            }
+          ]
+        },
+        {
           "begin": "(?<=>)",
           "end": "(?=<\\/)",
           "name": "text.hsml",

--- a/syntaxes/vue-hsml.tmLanguage.json
+++ b/syntaxes/vue-hsml.tmLanguage.json
@@ -28,19 +28,39 @@
           },
           "patterns": [
             {
-              "match": "\\b(lang)\\s*=\\s*(['\"])(hsml)\\2",
+              "match": "\\b(lang)\\s*=\\s*(\")(hsml)(\")",
               "captures": {
                 "1": { "name": "entity.other.attribute-name.html.vue" },
                 "2": { "name": "punctuation.definition.string.begin.html.vue" },
-                "3": { "name": "string.quoted.html.vue" }
+                "3": { "name": "string.quoted.html.vue" },
+                "4": { "name": "punctuation.definition.string.end.html.vue" }
               }
             },
             {
-              "match": "\\b([a-zA-Z-]+)\\s*=\\s*(['\"])([^'\"]*?)\\2",
+              "match": "\\b(lang)\\s*=\\s*(')(hsml)(')",
               "captures": {
                 "1": { "name": "entity.other.attribute-name.html.vue" },
                 "2": { "name": "punctuation.definition.string.begin.html.vue" },
-                "3": { "name": "string.quoted.html.vue" }
+                "3": { "name": "string.quoted.html.vue" },
+                "4": { "name": "punctuation.definition.string.end.html.vue" }
+              }
+            },
+            {
+              "match": "\\b([a-zA-Z-]+)\\s*=\\s*(\")(.*?)(\")",
+              "captures": {
+                "1": { "name": "entity.other.attribute-name.html.vue" },
+                "2": { "name": "punctuation.definition.string.begin.html.vue" },
+                "3": { "name": "string.quoted.html.vue" },
+                "4": { "name": "punctuation.definition.string.end.html.vue" }
+              }
+            },
+            {
+              "match": "\\b([a-zA-Z-]+)\\s*=\\s*(')(.*?)(')",
+              "captures": {
+                "1": { "name": "entity.other.attribute-name.html.vue" },
+                "2": { "name": "punctuation.definition.string.begin.html.vue" },
+                "3": { "name": "string.quoted.html.vue" },
+                "4": { "name": "punctuation.definition.string.end.html.vue" }
               }
             }
           ]

--- a/tests/grammar.test.ts
+++ b/tests/grammar.test.ts
@@ -4,13 +4,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { loadWASM, OnigScanner, OnigString } from 'vscode-oniguruma';
 import type { IGrammar } from 'vscode-textmate';
 import { INITIAL, Registry, parseRawGrammar } from 'vscode-textmate';
+import type { Token } from './utils.js';
+import { findToken } from './utils.js';
 
 let grammar: IGrammar;
-
-interface Token {
-  text: string;
-  scopes: string[];
-}
 
 function tokenize(line: string): Token[] {
   const result = grammar.tokenizeLine(line, INITIAL);
@@ -18,10 +15,6 @@ function tokenize(line: string): Token[] {
     text: line.substring(token.startIndex, token.endIndex),
     scopes: token.scopes,
   }));
-}
-
-function findToken(tokens: Token[], scope: string): Token | undefined {
-  return tokens.find((t) => t.scopes.some((s) => s === scope));
 }
 
 beforeAll(async () => {

--- a/tests/grammar.test.ts
+++ b/tests/grammar.test.ts
@@ -2,7 +2,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { loadWASM, OnigScanner, OnigString } from 'vscode-oniguruma';
-import { type IGrammar, INITIAL, Registry, parseRawGrammar } from 'vscode-textmate';
+import type { IGrammar } from 'vscode-textmate';
+import { INITIAL, Registry, parseRawGrammar } from 'vscode-textmate';
 
 let grammar: IGrammar;
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,8 @@
+export interface Token {
+  text: string;
+  scopes: string[];
+}
+
+export function findToken(tokens: Token[], scope: string): Token | undefined {
+  return tokens.find((t) => t.scopes.some((s) => s === scope));
+}

--- a/tests/vue-sfc.test.ts
+++ b/tests/vue-sfc.test.ts
@@ -4,17 +4,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { loadWASM, OnigScanner, OnigString } from 'vscode-oniguruma';
 import type { IGrammar, IOnigLib } from 'vscode-textmate';
 import { INITIAL, Registry, parseRawGrammar } from 'vscode-textmate';
+import type { Token } from './utils.js';
+import { findToken } from './utils.js';
 
 let grammar: IGrammar;
-
-interface Token {
-  text: string;
-  scopes: string[];
-}
-
-function findToken(tokens: Token[], scope: string): Token | undefined {
-  return tokens.find((t) => t.scopes.some((s) => s === scope));
-}
 
 beforeAll(async () => {
   const wasmBin = readFileSync(
@@ -89,6 +82,30 @@ describe('Vue SFC HSML embedding', () => {
   it('should highlight hsml as string value', () => {
     const results = tokenizeLines(['<template lang="hsml">', '</template>']);
     expect(findToken(results[0]!.tokens, 'string.quoted.html.vue')?.text).toBe('hsml');
+  });
+
+  it('should highlight opening quote of lang value', () => {
+    const results = tokenizeLines(['<template lang="hsml">', '</template>']);
+    expect(
+      findToken(results[0]!.tokens, 'punctuation.definition.string.begin.html.vue')?.text,
+    ).toBe('"');
+  });
+
+  it('should highlight closing quote of lang value', () => {
+    const results = tokenizeLines(['<template lang="hsml">', '</template>']);
+    expect(findToken(results[0]!.tokens, 'punctuation.definition.string.end.html.vue')?.text).toBe(
+      '"',
+    );
+  });
+
+  it('should highlight single quotes for lang value', () => {
+    const results = tokenizeLines(["<template lang='hsml'>", '</template>']);
+    expect(
+      findToken(results[0]!.tokens, 'punctuation.definition.string.begin.html.vue')?.text,
+    ).toBe("'");
+    expect(findToken(results[0]!.tokens, 'punctuation.definition.string.end.html.vue')?.text).toBe(
+      "'",
+    );
   });
 
   it('should highlight closing >', () => {

--- a/tests/vue-sfc.test.ts
+++ b/tests/vue-sfc.test.ts
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { loadWASM, OnigScanner, OnigString } from 'vscode-oniguruma';
+import type { IGrammar, IOnigLib } from 'vscode-textmate';
+import { INITIAL, Registry, parseRawGrammar } from 'vscode-textmate';
+
+let grammar: IGrammar;
+
+interface Token {
+  text: string;
+  scopes: string[];
+}
+
+function findToken(tokens: Token[], scope: string): Token | undefined {
+  return tokens.find((t) => t.scopes.some((s) => s === scope));
+}
+
+beforeAll(async () => {
+  const wasmBin = readFileSync(
+    join(import.meta.dirname, '../node_modules/vscode-oniguruma/release/onig.wasm'),
+  ).buffer;
+
+  await loadWASM(wasmBin);
+
+  const onigLib: IOnigLib = {
+    createOnigScanner: (patterns: string[]) => new OnigScanner(patterns),
+    createOnigString: (s: string) => new OnigString(s),
+  };
+
+  const registry = new Registry({
+    onigLib: Promise.resolve(onigLib),
+    loadGrammar: async (scopeName) => {
+      if (scopeName === 'text.hsml') {
+        const grammarPath = join(import.meta.dirname, '../syntaxes/hsml.tmLanguage.json');
+        return parseRawGrammar(readFileSync(grammarPath, 'utf-8'), grammarPath);
+      }
+      if (scopeName === 'vue.hsml.codeblock') {
+        const grammarPath = join(import.meta.dirname, '../syntaxes/vue-hsml.tmLanguage.json');
+        return parseRawGrammar(readFileSync(grammarPath, 'utf-8'), grammarPath);
+      }
+      if (scopeName === 'text.html.vue') {
+        // Minimal Vue grammar that includes our injection
+        return parseRawGrammar(
+          JSON.stringify({
+            scopeName: 'text.html.vue',
+            patterns: [{ include: 'vue.hsml.codeblock' }],
+          }),
+          'vue.json',
+        );
+      }
+      return null;
+    },
+  });
+
+  const loaded = await registry.loadGrammar('text.html.vue');
+  if (!loaded) throw new Error('Failed to load grammar');
+  grammar = loaded;
+});
+
+function tokenizeLines(lines: string[]): { line: string; tokens: Token[] }[] {
+  let ruleStack = INITIAL;
+  return lines.map((line) => {
+    const r = grammar.tokenizeLine(line, ruleStack);
+    ruleStack = r.ruleStack;
+    return {
+      line,
+      tokens: r.tokens.map((t) => ({
+        text: line.substring(t.startIndex, t.endIndex),
+        scopes: t.scopes,
+      })),
+    };
+  });
+}
+
+describe('Vue SFC HSML embedding', () => {
+  it('should highlight template tag name', () => {
+    const results = tokenizeLines(['<template lang="hsml">', '</template>']);
+    expect(findToken(results[0]!.tokens, 'entity.name.tag.template.html.vue')).toBeDefined();
+  });
+
+  it('should highlight lang attribute', () => {
+    const results = tokenizeLines(['<template lang="hsml">', '</template>']);
+    expect(findToken(results[0]!.tokens, 'entity.other.attribute-name.html.vue')?.text).toBe(
+      'lang',
+    );
+  });
+
+  it('should highlight hsml as string value', () => {
+    const results = tokenizeLines(['<template lang="hsml">', '</template>']);
+    expect(findToken(results[0]!.tokens, 'string.quoted.html.vue')?.text).toBe('hsml');
+  });
+
+  it('should highlight closing >', () => {
+    const results = tokenizeLines(['<template lang="hsml">', '</template>']);
+    expect(findToken(results[0]!.tokens, 'punctuation.definition.tag.end.html.vue')?.text).toBe(
+      '>',
+    );
+  });
+
+  it('should highlight HSML tag names inside template', () => {
+    const results = tokenizeLines(['<template lang="hsml">', 'div.container', '</template>']);
+    expect(findToken(results[1]!.tokens, 'entity.name.tag.hsml')?.text).toBe('div');
+  });
+
+  it('should highlight HSML classes inside template', () => {
+    const results = tokenizeLines(['<template lang="hsml">', 'div.container', '</template>']);
+    expect(findToken(results[1]!.tokens, 'entity.other.attribute-name.class.css.hsml')?.text).toBe(
+      'container',
+    );
+  });
+
+  it('should highlight closing template tag', () => {
+    const results = tokenizeLines(['<template lang="hsml">', 'div', '</template>']);
+    expect(findToken(results[2]!.tokens, 'punctuation.definition.tag.begin.html.vue')?.text).toBe(
+      '</',
+    );
+    expect(findToken(results[2]!.tokens, 'entity.name.tag.template.html.vue')).toBeDefined();
+  });
+
+  it('should work with single-quoted lang attribute', () => {
+    const results = tokenizeLines(["<template lang='hsml'>", 'h1 Hello', '</template>']);
+    expect(findToken(results[1]!.tokens, 'entity.name.tag.hsml')?.text).toBe('h1');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Syntax highlighting for HSML code blocks inside Vue SFCs when using lang="hsml".

* **Tests**
  * Added end-to-end tests validating token scopes, attribute recognition, quoted lang values, and embedded HSML content in Vue templates.
  * New test utilities to simplify token lookup and assertions.

* **Refactor**
  * Cleaned up test imports and organization for clearer, type-safe usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->