### PR TITLE
feat: add restart language server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ## Features
 
-- Syntax highlighting for `.hsml` files
-- Diagnostics and hover via the [hsml](https://github.com/hsml-lab/hsml) language server
+- Syntax highlighting for `.hsml` files and `<template lang="hsml">` in Vue SFCs
+- Diagnostics, hover, and formatting via the [hsml](https://github.com/hsml-lab/hsml) language server
 - Auto-download of the `hsml` binary from GitHub releases
 - Comment toggling (`//` line comments)
 - Bracket matching and auto-closing pairs

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,12 +1,12 @@
 import type { ExtensionContext } from 'vscode';
-import { workspace } from 'vscode';
+import { commands, workspace } from 'vscode';
 import type { Executable, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { resolveServerPath } from './binary.js';
 
 let client: LanguageClient | undefined;
 
-export async function activate(context: ExtensionContext) {
+async function startClient(context: ExtensionContext): Promise<void> {
   const serverPath = await resolveServerPath(context);
   if (!serverPath) {
     return;
@@ -36,7 +36,21 @@ export async function activate(context: ExtensionContext) {
     clientOptions,
   );
 
-  client.start();
+  await client.start();
+}
+
+export async function activate(context: ExtensionContext) {
+  context.subscriptions.push(
+    commands.registerCommand('hsml.restartLanguageServer', async () => {
+      if (client) {
+        await client.restart();
+      } else {
+        await startClient(context);
+      }
+    }),
+  );
+
+  await startClient(context);
 }
 
 export function deactivate(): Promise<void> | undefined {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,12 @@
     "vscode-tmgrammar-test": "0.1.3"
   },
   "contributes": {
+    "commands": [
+      {
+        "command": "hsml.restartLanguageServer",
+        "title": "HSML: Restart Language Server"
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "HSML configuration",

--- a/tests/__mocks__/vscode-languageclient-node.ts
+++ b/tests/__mocks__/vscode-languageclient-node.ts
@@ -2,8 +2,10 @@ import { vi } from 'vitest';
 
 export const mockStart = vi.fn();
 export const mockStop = vi.fn(() => Promise.resolve());
+export const mockRestart = vi.fn(() => Promise.resolve());
 
 export class LanguageClient {
   start = mockStart;
   stop = mockStop;
+  restart = mockRestart;
 }

--- a/tests/__mocks__/vscode-languageclient-node.ts
+++ b/tests/__mocks__/vscode-languageclient-node.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-export const mockStart = vi.fn();
+export const mockStart = vi.fn(() => Promise.resolve());
 export const mockStop = vi.fn(() => Promise.resolve());
 export const mockRestart = vi.fn(() => Promise.resolve());
 

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -28,4 +28,7 @@ export const Uri = {
 
 export const commands = {
   executeCommand: vi.fn(),
+  registerCommand: vi.fn((_command: string, _callback: (...args: unknown[]) => unknown) => ({
+    dispose: vi.fn(),
+  })),
 };

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -39,9 +39,7 @@ describe('activate', () => {
 
     expect(mockStart).toHaveBeenCalled();
   });
-});
 
-describe('activate', () => {
   it('should register restart command', async () => {
     const { commands } = await import('vscode');
     const { activate } = await import('../client/src/extension.js');

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -4,6 +4,7 @@ import { resolveServerPath } from './__mocks__/binary.js';
 
 const mockContext = {
   globalStorageUri: { fsPath: '/tmp/test-storage' },
+  subscriptions: [],
 } as unknown as ExtensionContext;
 
 beforeEach(() => {
@@ -37,6 +38,37 @@ describe('activate', () => {
     await activate(mockContext);
 
     expect(mockStart).toHaveBeenCalled();
+  });
+});
+
+describe('activate', () => {
+  it('should register restart command', async () => {
+    const { commands } = await import('vscode');
+    const { activate } = await import('../client/src/extension.js');
+    await activate(mockContext);
+
+    expect(commands.registerCommand).toHaveBeenCalledWith(
+      'hsml.restartLanguageServer',
+      expect.any(Function),
+    );
+  });
+});
+
+describe('restart command', () => {
+  it('should call restart on existing client', async () => {
+    const { commands } = await import('vscode');
+    const { mockRestart } = await import('./__mocks__/vscode-languageclient-node.js');
+    const { activate } = await import('../client/src/extension.js');
+    await activate(mockContext);
+
+    // Get the registered callback
+    const registerCall = (commands.registerCommand as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0] === 'hsml.restartLanguageServer',
+    );
+    const restartCallback = registerCall?.[1] as () => Promise<void>;
+    await restartCallback();
+
+    expect(mockRestart).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Restart Language Server" command accessible from the command palette
  * Extended syntax highlighting support to Vue Single File Components' template blocks
  * Language server now provides formatting capabilities in addition to diagnostics and hover features

* **Documentation**
  * Updated feature documentation to reflect expanded syntax highlighting and language server capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->